### PR TITLE
fix (excel export): html source code leak in Excel export functionality

### DIFF
--- a/dist/cjs/lib/HTMLReportGenerator.js
+++ b/dist/cjs/lib/HTMLReportGenerator.js
@@ -98,11 +98,11 @@ class HTMLReportGenerator {
     };
 
     // Format the start and end date into the desired format: "Tue, 08 Apr 2025 21:16:16 GMT"
-    const startDateStr = (metadata.executionStartTime !== 'N/A') 
-      ? new Date(metadata.executionStartTime).toUTCString() 
+    const startDateStr = (metadata.executionStartTime !== 'N/A')
+      ? new Date(metadata.executionStartTime).toUTCString()
       : 'N/A';
-    const endDateStr = (metadata.executionEndTime !== 'N/A') 
-      ? new Date(metadata.executionEndTime).toUTCString() 
+    const endDateStr = (metadata.executionEndTime !== 'N/A')
+      ? new Date(metadata.executionEndTime).toUTCString()
       : 'N/A';
 
     // Compute suite statistics for current run
@@ -1287,7 +1287,7 @@ class HTMLReportGenerator {
       }
       htmlTable += '</tbody></table>';
       
-      var htmlContent = '<html><head><meta charset="UTF-8">' + style + '</head><body>' + htmlTable + '</body></html>';
+      var htmlContent = '<html><head><meta charset="UTF-8">' + style + '</head><body>' + htmlTable + '</'+'body'+'></'+'html'+'>';
       
       var downloadLink = document.createElement("a");
       document.body.appendChild(downloadLink);

--- a/dist/esm/lib/HTMLReportGenerator.js
+++ b/dist/esm/lib/HTMLReportGenerator.js
@@ -1274,7 +1274,7 @@ class HTMLReportGenerator {
       }
       htmlTable += '</tbody></table>';
       
-      var htmlContent = '<html><head><meta charset="UTF-8">' + style + '</head><body>' + htmlTable + '</body></html>';
+      var htmlContent = '<html><head><meta charset="UTF-8">' + style + '</head><body>' + htmlTable + '</'+'body'+'></'+'html'+'>';
       
       var downloadLink = document.createElement("a");
       document.body.appendChild(downloadLink);

--- a/lib/HTMLReportGenerator.js
+++ b/lib/HTMLReportGenerator.js
@@ -98,11 +98,11 @@ class HTMLReportGenerator {
     };
 
     // Format the start and end date into the desired format: "Tue, 08 Apr 2025 21:16:16 GMT"
-    const startDateStr = (metadata.executionStartTime !== 'N/A') 
-      ? new Date(metadata.executionStartTime).toUTCString() 
+    const startDateStr = (metadata.executionStartTime !== 'N/A')
+      ? new Date(metadata.executionStartTime).toUTCString()
       : 'N/A';
-    const endDateStr = (metadata.executionEndTime !== 'N/A') 
-      ? new Date(metadata.executionEndTime).toUTCString() 
+    const endDateStr = (metadata.executionEndTime !== 'N/A')
+      ? new Date(metadata.executionEndTime).toUTCString()
       : 'N/A';
 
     // Compute suite statistics for current run
@@ -1287,7 +1287,7 @@ class HTMLReportGenerator {
       }
       htmlTable += '</tbody></table>';
       
-      var htmlContent = '<html><head><meta charset="UTF-8">' + style + '</head><body>' + htmlTable + '</body></html>';
+      var htmlContent = '<html><head><meta charset="UTF-8">' + style + '</head><body>' + htmlTable + '</'+'body'+'></'+'html'+'>';
       
       var downloadLink = document.createElement("a");
       document.body.appendChild(downloadLink);


### PR DESCRIPTION
**Problem:**

Found HTML source code leak into browser view as shown below:
<img width="1919" height="1079" alt="Screenshot 2025-07-27 145803" src="https://github.com/user-attachments/assets/826b016a-24ea-40b6-aff3-cd59c46b8796" />

This leak is from exportTableToExcel function. The closing </html> tag in the HTML content string was being interpreted by browsers as a complete HTML document when embedded in data URIs. So all the source code after this tag, is displayed as plain text in browser view.

**Solution:**
A small hack of splitting tags into multiple parts of string and concatening them

What's Fixed

✅ No more HTML code showing up instead of file downloads
✅ No other features broken


The gist below contains reports pre-&post- the fix:
https://gist.github.com/mrtejesh-tm/7e6b969fb032cc52bb30233cf235a437
